### PR TITLE
[Vault-4597] Increase Orchestrator TTL to effective max

### DIFF
--- a/setup/vault-server/entrypoint.sh
+++ b/setup/vault-server/entrypoint.sh
@@ -58,7 +58,7 @@ vault write auth/approle/role/dev-role/role-id role_id="${APPROLE_ROLE_ID}"
 vault token create \
     -id="${ORCHESTRATOR_TOKEN}" \
     -policy=trusted-orchestrator-policy \
-    -ttl=2h
+    -ttl=768h
 
 #####################################
 ########## STATIC SECRETS ###########

--- a/setup/vault-server/entrypoint.sh
+++ b/setup/vault-server/entrypoint.sh
@@ -55,7 +55,7 @@ vault write auth/approle/role/dev-role/role-id role_id="${APPROLE_ROLE_ID}"
 
 # configure a token with permissions to act as a trusted orchestrator
 # nb: for simplicity, we don't handle renewals in our simulated orchestrator
-# so we've set the ttl to a very long duration (768h), when this expires
+# so we've set the ttl to a very long duration (768h); when this expires
 # the web app will no longer receive a SecretID and subsequently fail on the
 # next attempted AppRole login
 # ref: https://www.vaultproject.io/docs/commands/token/create

--- a/setup/vault-server/entrypoint.sh
+++ b/setup/vault-server/entrypoint.sh
@@ -54,6 +54,10 @@ vault write auth/approle/role/dev-role/role-id role_id="${APPROLE_ROLE_ID}"
 #####################################
 
 # configure a token with permissions to act as a trusted orchestrator
+# nb: for simplicity, we don't handle renewals in our simulated orchestrator
+# so we've set the ttl to a very long duration (768h), when this expires
+# the web app will no longer receive a SecretID and subsequently fail on the
+# next attempted AppRole login
 # ref: https://www.vaultproject.io/docs/commands/token/create
 vault token create \
     -id="${ORCHESTRATOR_TOKEN}" \


### PR DESCRIPTION
Increase the TTL to `768h` (the default upper bound of TTLs assigned to our root token) on the token our `trusted-orchestrator` container uses.
https://www.vaultproject.io/docs/configuration#default_lease_ttl