### PR TITLE
[VAULT-4606] Fix issue with database credentials expiring early

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - "8200:8200"
     depends_on:
       database:
-        condition: service_started
+        condition: service_healthy
 
   trusted-orchestrator:
     build: ./setup/trusted-orchestrator

--- a/setup/vault-server/entrypoint.sh
+++ b/setup/vault-server/entrypoint.sh
@@ -99,8 +99,8 @@ vault write -force database/config/my-postgresql-database
 vault write database/roles/dev-readonly \
     db_name=my-postgresql-database \
     creation_statements="CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}'; GRANT readonly TO \"{{name}}\";" \
-    default_ttl="40s"
-    max_ttl="2m"  # artificially low to demonstrate credential renewal logic
+    default_ttl="3m" \
+    max_ttl="7m"  # artificially low to demonstrate credential renewal logic
 
 # this container is now healthy
 touch /tmp/healthy


### PR DESCRIPTION
The root cause of the issue was the missing `\` line break in the shell script. I'm also adding a bit more logging to expose the remaining lease duration at different stages of renewal.