### PR TITLE
Fix shellcheck warnings

### DIFF
--- a/setup/trusted-orchestrator/entrypoint.sh
+++ b/setup/trusted-orchestrator/entrypoint.sh
@@ -14,7 +14,7 @@ finish() {
   exit
 }
 
-trap finish SIGINT SIGTERM
+trap finish INT TERM
 
 # using the orchestrator token, generate a new wrapped SecretID on a regular cadence
 # ref: https://www.vaultproject.io/api-docs/auth/approle#generate-new-secret-id
@@ -26,7 +26,7 @@ while true; do
        --request POST \
        --header "X-Vault-Token: ${ORCHESTRATOR_TOKEN}" \
        --header "X-Vault-Wrap-TTL: 5m" \
-          ${VAULT_ADDRESS}/v1/auth/approle/role/dev-role/secret-id | jq -r '.wrap_info.token' > /tmp/secret
+          "${VAULT_ADDRESS}/v1/auth/approle/role/dev-role/secret-id" | jq -r '.wrap_info.token' > /tmp/secret
 
   echo "$(date +"%T"): $?"
   echo "$(date +"%T"): wrote wrapped secret id to /tmp/secret"

--- a/setup/vault-server/entrypoint.sh
+++ b/setup/vault-server/entrypoint.sh
@@ -62,7 +62,7 @@ vault write auth/approle/role/dev-role/role-id role_id="${APPROLE_ROLE_ID}"
 vault token create \
     -id="${ORCHESTRATOR_TOKEN}" \
     -policy=trusted-orchestrator-policy \
-    -ttl=768h
+    -ttl="768h"
 
 #####################################
 ########## STATIC SECRETS ###########
@@ -99,11 +99,11 @@ vault write -force database/config/my-postgresql-database
 vault write database/roles/dev-readonly \
     db_name=my-postgresql-database \
     creation_statements="CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}'; GRANT readonly TO \"{{name}}\";" \
-    default_ttl="40s"
+    default_ttl="40s" \
     max_ttl="2m"  # artificially low to demonstrate credential renewal logic
 
 # this container is now healthy
 touch /tmp/healthy
 
 # keep container alive
-tail -f /dev/null & trap 'kill %1' SIGTERM ; wait
+tail -f /dev/null & trap 'kill %1' TERM ; wait

--- a/setup/vault-server/entrypoint.sh
+++ b/setup/vault-server/entrypoint.sh
@@ -99,7 +99,7 @@ vault write -force database/config/my-postgresql-database
 vault write database/roles/dev-readonly \
     db_name=my-postgresql-database \
     creation_statements="CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}'; GRANT readonly TO \"{{name}}\";" \
-    default_ttl="40s" \
+    default_ttl="40s"
     max_ttl="2m"  # artificially low to demonstrate credential renewal logic
 
 # this container is now healthy


### PR DESCRIPTION
`shellcheck` came up with a few warnings, addressing them here. Also adding quotes around `-ttl="768h"` for consistency.