### PR TITLE
Log the username part of database credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ docker logs hello-vault-go-app-1
 
 ```log
 ...
-2021/12/10 23:20:36 getting secret api key from vault
-2021/12/10 23:20:36 getting secret api key from vault: success!
-[GIN] 2021/12/10 - 23:20:36 | 200 |    3.219167ms |    192.168.96.1 | POST     "/payments"
+2021/12/15 23:15:36 getting secret api key from vault
+2021/12/15 23:15:36 getting secret api key from vault: success!
+[GIN] 2021/12/15 23:15:36 | 200 |    3.219167ms |    192.168.96.1 | POST     "/payments"
 ```
 
 ### 3. Try out `GET /products` endpoint (dynamic secrets workflow)
@@ -113,12 +113,12 @@ docker logs hello-vault-go-app-1
 ```
 
 ```log
-2021/12/10 23:20:15 getting temporary database credentials from vault
-2021/12/10 23:20:15 getting temporary database credentials from vault: success!
-2021/12/10 23:20:15 connecting to "postgres" database @ db:5432
-2021/12/10 23:20:15 connecting to "postgres" database: success!
+2021/12/15 23:17:49 getting temporary database credentials from vault
+2021/12/15 23:17:49 getting temporary database credentials from vault: success!
+2021/12/15 23:17:49 connecting to "postgres" database @ database:5432 with username "v-approle-dev-read-dBbQdpLrIv8Xyh8nwzSX-1639610269"
+2021/12/15 23:17:49 connecting to "postgres" database: success!
 ...
-[GIN] 2021/12/10 - 23:25:22 | 200 |    2.559083ms |    192.168.96.1 | GET      "/products"
+[GIN] 2021/12/15 - 23:18:22 | 200 |    2.559083ms |    192.168.96.1 | GET      "/products"
 ```
 
 ### 4. Examine the logs for renew logic
@@ -134,21 +134,21 @@ docker logs hello-vault-go-app-1 2>&1 | grep auth
 ```
 
 ```log
-2021/12/10 23:20:15 logging in to vault with approle auth; role id: demo-web-app
-2021/12/10 23:20:15 logging in to vault with approle auth: success!
-2021/12/10 23:20:15 auth token renew / login loop: begin
-2021/12/10 23:20:15 auth token renew cycle: started
-2021/12/10 23:20:15 auth token: successfully renewed
-2021/12/10 23:20:58 auth token: successfully renewed
-2021/12/10 23:21:41 auth token: successfully renewed
-2021/12/10 23:22:23 auth token: successfully renewed
-2021/12/10 23:23:01 auth token: successfully renewed
-2021/12/10 23:23:01 auth token renew cycle: the secret can no longer be renewed
-2021/12/10 23:23:01 logging in to vault with approle auth; role id: demo-web-app
-2021/12/10 23:23:01 logging in to vault with approle auth: success!
-2021/12/10 23:23:01 auth token renew cycle: started
-2021/12/10 23:23:01 auth token: successfully renewed
-2021/12/10 23:23:44 auth token: successfully renewed
+2021/12/15 23:17:49 logging in to vault with approle auth; role id: demo-web-app
+2021/12/15 23:17:49 logging in to vault with approle auth: success!
+2021/12/15 23:17:49 auth token renew / login loop: begin
+2021/12/15 23:17:49 auth token renew cycle: started; lease duration: 0s
+2021/12/15 23:17:49 auth token: successfully renewed; remaining lease duration: 0s
+2021/12/15 23:19:15 auth token: successfully renewed; remaining lease duration: 0s
+2021/12/15 23:20:40 auth token: successfully renewed; remaining lease duration: 0s
+2021/12/15 23:22:06 auth token: successfully renewed; remaining lease duration: 0s
+2021/12/15 23:23:21 auth token: successfully renewed; remaining lease duration: 0s
+2021/12/15 23:23:21 auth token renew cycle: the secret can no longer be renewed
+2021/12/15 23:23:21 logging in to vault with approle auth; role id: demo-web-app
+2021/12/15 23:23:21 logging in to vault with approle auth: success!
+2021/12/15 23:23:21 auth token renew cycle: started; lease duration: 0s
+2021/12/15 23:23:21 auth token: successfully renewed; remaining lease duration: 0s
+2021/12/15 23:24:46 auth token: successfully renewed; remaining lease duration: 0s
 ```
 
 Examine the logs for database credentials renew / reconnect cycle:
@@ -158,25 +158,25 @@ docker logs hello-vault-go-app-1 2>&1 | grep database
 ```
 
 ```log
-2021/12/10 23:20:15 getting temporary database credentials from vault
-2021/12/10 23:20:15 getting temporary database credentials from vault: success!
-2021/12/10 23:20:15 connecting to "postgres" database @ db:5432
-2021/12/10 23:20:15 connecting to "postgres" database: success!
-2021/12/10 23:20:15 database credentials renew / reconnect loop: begin
-2021/12/10 23:20:15 database credentials renew cycle: started
-2021/12/10 23:20:15 database credentials: successfully renewed
-2021/12/10 23:20:43 database credentials: successfully renewed
-2021/12/10 23:21:12 database credentials: successfully renewed
-2021/12/10 23:21:41 database credentials: successfully renewed
-2021/12/10 23:22:05 database credentials: successfully renewed
-2021/12/10 23:22:05 database credentials renew cycle: the secret can no longer be renewed
-2021/12/10 23:22:05 getting temporary database credentials from vault
-2021/12/10 23:22:05 getting temporary database credentials from vault: success!
-2021/12/10 23:22:05 connecting to "postgres" database @ db:5432
-2021/12/10 23:22:05 connecting to "postgres" database: success!
-2021/12/10 23:22:05 database credentials renew cycle: started
-2021/12/10 23:22:05 database credentials: successfully renewed
-2021/12/10 23:22:35 database credentials: successfully renewed
+2021/12/15 23:17:49 getting temporary database credentials from vault
+2021/12/15 23:17:49 getting temporary database credentials from vault: success!
+2021/12/15 23:17:49 connecting to "postgres" database @ database:5432 with username "v-approle-dev-read-dBbQdpLrIv8Xyh8nwzSX-1639610269"
+2021/12/15 23:17:49 connecting to "postgres" database: success!
+2021/12/15 23:17:49 database credentials renew / reconnect loop: begin
+2021/12/15 23:17:49 database credentials renew cycle: started; lease duration: 180s
+2021/12/15 23:17:49 database credentials: successfully renewed; remaining lease duration: 180s
+2021/12/15 23:19:57 database credentials: successfully renewed; remaining lease duration: 180s
+2021/12/15 23:22:06 database credentials: successfully renewed; remaining lease duration: 163s
+2021/12/15 23:24:14 database credentials renew cycle: the secret can no longer be renewed
+2021/12/15 23:24:14 getting temporary database credentials from vault
+2021/12/15 23:24:14 getting temporary database credentials from vault: success!
+2021/12/15 23:24:14 connecting to "postgres" database @ database:5432 with username "v-approle-dev-read-TG9mg6avrhBO09f1HjEd-1639610654"
+2021/12/15 23:24:14 connecting to "postgres" database: success!
+2021/12/15 23:24:14 database credentials renew cycle: started; lease duration: 180s
+2021/12/15 23:24:14 database credentials: successfully renewed; remaining lease duration: 180s
+2021/12/15 23:26:21 database credentials: successfully renewed; remaining lease duration: 180s
+2021/12/15 23:28:27 database credentials: successfully renewed; remaining lease duration: 167s
+2021/12/15 23:30:37 database credentials renew cycle: the secret can no longer be renewed
 ```
 
 ## Stack Design

--- a/database.go
+++ b/database.go
@@ -60,10 +60,11 @@ func (db *Database) Reconnect(ctx context.Context, credentials DatabaseCredentia
 	defer cancelContextFunc()
 
 	log.Printf(
-		"connecting to %q database @ %s:%s",
+		"connecting to %q database @ %s:%s with username %q",
 		db.parameters.name,
 		db.parameters.hostname,
 		db.parameters.port,
+		credentials.Username,
 	)
 
 	connectionString := fmt.Sprintf(


### PR DESCRIPTION
This will better demonstrate how the credentials are rotated:

```log
$ docker logs hello-vault-go-app-1 2>&1 | grep database
2021/12/15 23:17:49 getting temporary database credentials from vault
2021/12/15 23:17:49 getting temporary database credentials from vault: success!
2021/12/15 23:17:49 connecting to "postgres" database @ database:5432 with username "v-approle-dev-read-dBbQdpLrIv8Xyh8nwzSX-1639610269"
2021/12/15 23:17:49 connecting to "postgres" database: success!
2021/12/15 23:17:49 database credentials renew / reconnect loop: begin
2021/12/15 23:17:49 database credentials renew cycle: started; lease duration: 180s
2021/12/15 23:17:49 database credentials: successfully renewed; remaining lease duration: 180s
2021/12/15 23:19:57 database credentials: successfully renewed; remaining lease duration: 180s
2021/12/15 23:22:06 database credentials: successfully renewed; remaining lease duration: 163s
2021/12/15 23:24:14 database credentials renew cycle: the secret can no longer be renewed
2021/12/15 23:24:14 getting temporary database credentials from vault
2021/12/15 23:24:14 getting temporary database credentials from vault: success!
2021/12/15 23:24:14 connecting to "postgres" database @ database:5432 with username "v-approle-dev-read-TG9mg6avrhBO09f1HjEd-1639610654"
```