### PR TITLE
Refactor API Key field name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       VAULT_APPROLE_SECRET_ID_FILE: /tmp/secret
       VAULT_DATABASE_CREDS_PATH:    database/creds/dev-readonly
       VAULT_API_KEY_PATH:           kv-v2/data/api-key
-      VAULT_API_KEY_DESCRIPTOR:     api-key-descriptor
+      VAULT_API_KEY_FIELD:          api-key-field
       DATABASE_HOSTNAME:            database
       DATABASE_PORT:                5432
       DATABASE_NAME:                postgres
@@ -39,9 +39,11 @@ services:
     environment:
       VAULT_DEV_ROOT_TOKEN_ID: root
       APPROLE_ROLE_ID:         demo-web-app
-      ORCHESTRATOR_TOKEN:      insecure_token
+      ORCHESTRATOR_TOKEN:      insecure-token
       DATABASE_HOSTNAME:       database
       DATABASE_PORT:           5432
+      API_KEY_PATH:            kv-v2/api-key
+      API_KEY_FIELD:           api-key-field
     ports:
       - "8200:8200"
     depends_on:
@@ -52,7 +54,7 @@ services:
     build: ./setup/trusted-orchestrator
     environment:
       VAULT_ADDRESS:      http://vault-server:8200
-      ORCHESTRATOR_TOKEN: insecure_token
+      ORCHESTRATOR_TOKEN: insecure-token
     volumes:
       - type:   volume
         source: trusted-orchestrator-volume

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       VAULT_APPROLE_SECRET_ID_FILE: /tmp/secret
       VAULT_DATABASE_CREDS_PATH:    database/creds/dev-readonly
       VAULT_API_KEY_PATH:           kv-v2/data/api-key
+      VAULT_API_KEY_DESCRIPTOR:     api-key-descriptor
       DATABASE_HOSTNAME:            database
       DATABASE_PORT:                5432
       DATABASE_NAME:                postgres

--- a/handlers.go
+++ b/handlers.go
@@ -17,16 +17,9 @@ type Handlers struct {
 // (POST /payments) : demonstrates fetching a static secret from Vault and using it to talk to another service
 func (h *Handlers) CreatePayment(c *gin.Context) {
 	// retrieve the secret from Vault
-	secret, err := h.vault.GetSecretAPIKey(c.Request.Context())
+	apiKey, err := h.vault.GetSecretAPIKey(c.Request.Context())
 	if err != nil {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
-		return
-	}
-
-	// check that our expected key is in the returned secret
-	apiKey, ok := secret["apiKey"]
-	if !ok {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "the secret retrieved from vault is missing 'apiKey' field"})
 		return
 	}
 
@@ -37,7 +30,7 @@ func (h *Handlers) CreatePayment(c *gin.Context) {
 	}
 
 	// use the api key in our request header
-	request.Header.Set("X-API-KEY", apiKey.(string))
+	request.Header.Set("X-API-KEY", apiKey)
 
 	response, err := http.DefaultClient.Do(request)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ type Environment struct {
 	VaultApproleRoleID       string `env:"VAULT_APPROLE_ROLE_ID"         required:"true"                        description:"AppRole RoleID to log in to Vault"                      long:"vault-approle-role-id"`
 	VaultApproleSecretIDFile string `env:"VAULT_APPROLE_SECRET_ID_FILE"  default:"/tmp/secret"                  description:"AppRole SecretID file path to log in to Vault"          long:"vault-approle-secret-id-file"`
 	VaultAPIKeyPath          string `env:"VAULT_API_KEY_PATH"            default:"kv-v2/data/api-key"           description:"Path to the API key used by 'secure-sevice'"            long:"vault-api-key-path"`
+	VaultAPIKeyField         string `env:"VAULT_API_KEY_FIELD"           default:"api-key-field"                description:"The secret field name for the API key"                  long:"vault-api-key-descriptor"`
 	VaultDatabaseCredsPath   string `env:"VAULT_DATABASE_CREDS_PATH"     default:"database/creds/dev-readonly"  description:"Temporary database credentials will be generated here"  long:"vault-database-creds-path"`
 
 	// We will connect to this database using Vault-generated dynamic credentials
@@ -64,11 +65,12 @@ func run(ctx context.Context, env Environment) error {
 	vault, token, err := NewVaultAppRoleClient(
 		ctx,
 		VaultParameters{
-			env.VaultAddress,
-			env.VaultApproleRoleID,
-			env.VaultApproleSecretIDFile,
-			env.VaultAPIKeyPath,
-			env.VaultDatabaseCredsPath,
+			address:                 env.VaultAddress,
+			approleRoleID:           env.VaultApproleRoleID,
+			approleSecretIDFile:     env.VaultApproleSecretIDFile,
+			apiKeyPath:              env.VaultAPIKeyPath,
+			apiKeyField:             env.VaultAPIKeyField,
+			databaseCredentialsPath: env.VaultDatabaseCredsPath,
 		},
 	)
 	if err != nil {

--- a/setup/vault-server/entrypoint.sh
+++ b/setup/vault-server/entrypoint.sh
@@ -73,7 +73,7 @@ vault token create \
 vault secrets enable -path=kv-v2 kv-v2
 
 # seed the kv-v2 store with an entry our web app will use
-vault kv put kv-v2/api-key api-key-field=my-secret-key
+vault kv put "${API_KEY_PATH}" "${API_KEY_FIELD}=my-secret-key"
 
 #####################################
 ########## DYNAMIC SECRETS ##########

--- a/setup/vault-server/entrypoint.sh
+++ b/setup/vault-server/entrypoint.sh
@@ -73,7 +73,7 @@ vault token create \
 vault secrets enable -path=kv-v2 kv-v2
 
 # seed the kv-v2 store with an entry our web app will use
-vault kv put kv-v2/api-key apiKey=my-secret-key
+vault kv put kv-v2/api-key api-key-field=my-secret-key
 
 #####################################
 ########## DYNAMIC SECRETS ##########

--- a/vault.go
+++ b/vault.go
@@ -16,7 +16,7 @@ type VaultParameters struct {
 	approleRoleID       string
 	approleSecretIDFile string
 
-	// the locations / descriptors of our two secrets
+	// the locations / field names of our two secrets
 	apiKeyPath              string
 	apiKeyField             string
 	databaseCredentialsPath string


### PR DESCRIPTION
In the main branch, the API Key path is passed to our go app through an environment variable but the API Key field name is hardcoded. Moreover, the API Key field name is separated out into a different function, which is not great.

This PR will:

- extract API Key field out into an environment variable
- refactor GetSecretAPIKey to return the actual API Key