### PR TITLE
Remove unused context parameters

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -17,7 +17,7 @@ type Handlers struct {
 // (POST /payments) : demonstrates fetching a static secret from Vault and using it to talk to another service
 func (h *Handlers) CreatePayment(c *gin.Context) {
 	// retrieve the secret from Vault
-	apiKey, err := h.vault.GetSecretAPIKey(c.Request.Context())
+	apiKey, err := h.vault.GetSecretAPIKey()
 	if err != nil {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
 		return

--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ func run(ctx context.Context, env Environment) error {
 	go vault.RenewLoginPeriodically(ctx, token) // keep alive
 
 	// database
-	credentials, secret, err := vault.GetDatabaseCredentials(ctx)
+	credentials, secret, err := vault.GetDatabaseCredentials()
 	if err != nil {
 		return fmt.Errorf("unable to retrieve database credentials from vault: %w", err)
 	}

--- a/vault-renewal.go
+++ b/vault-renewal.go
@@ -73,7 +73,7 @@ func (v *Vault) RenewDatabaseCredentialsPeriodically(
 			}
 
 			// database credentials have expired and need to be renewed
-			credentials, secret, err := v.GetDatabaseCredentials(ctx)
+			credentials, secret, err := v.GetDatabaseCredentials()
 			if err != nil {
 				log.Fatalf("database credentials error: %v", err) // simplified error handling
 			}

--- a/vault.go
+++ b/vault.go
@@ -95,7 +95,7 @@ func (v *Vault) login(ctx context.Context) (*vault.Secret, error) {
 }
 
 // GetSecretAPIKey fetches the latest version of secret api key from kv-v2
-func (v *Vault) GetSecretAPIKey(ctx context.Context) (string, error) {
+func (v *Vault) GetSecretAPIKey() (string, error) {
 	log.Println("getting secret api key from vault")
 
 	secret, err := v.client.Logical().Read(v.parameters.apiKeyPath)
@@ -124,7 +124,7 @@ func (v *Vault) GetSecretAPIKey(ctx context.Context) (string, error) {
 }
 
 // GetDatabaseCredentials retrieves a new set of temporary database credentials
-func (v *Vault) GetDatabaseCredentials(ctx context.Context) (DatabaseCredentials, *vault.Secret, error) {
+func (v *Vault) GetDatabaseCredentials() (DatabaseCredentials, *vault.Secret, error) {
 	log.Println("getting temporary database credentials from vault")
 
 	secret, err := v.client.Logical().Read(v.parameters.databaseCredentialsPath)


### PR DESCRIPTION
Unfortunately, the current `VaultClient.Logical().Read(string path)` is not context-aware. This pull request is removing the unused context parameter passed to `GetSecretAPIKey()` and `GetDatabaseCredentials()`.