### PR TITLE
Add remaining duration log for auth token

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,18 +140,18 @@ docker logs hello-vault-go-app-1 2>&1 | grep auth
 ```log
 2022/01/11 20:22:55 logging in to vault with approle auth; role id: demo-web-app
 2022/01/11 20:22:55 logging in to vault with approle auth: success!
-2022/01/11 20:22:55 auth token: successfully renewed
-2022/01/11 20:24:21 auth token: successfully renewed
-2022/01/11 20:25:47 auth token: successfully renewed
-2022/01/11 20:27:13 auth token: successfully renewed
-2022/01/11 20:27:33 auth token: successfully renewed
-2022/01/11 20:28:34 auth token: successfully renewed
+2022/01/11 20:22:55 auth token: successfully renewed; remaining duration: 120s
+2022/01/11 20:24:21 auth token: successfully renewed; remaining duration: 120s
+2022/01/11 20:25:47 auth token: successfully renewed; remaining duration: 120s
+2022/01/11 20:27:13 auth token: successfully renewed; remaining duration: 120s
+2022/01/11 20:27:33 auth token: successfully renewed; remaining duration: 120s
+2022/01/11 20:28:34 auth token: successfully renewed; remaining duration: 105s
 2022/01/11 20:28:34 auth token: can no longer be renewed; will log in again
 2022/01/11 20:28:34 logging in to vault with approle auth; role id: demo-web-app
 2022/01/11 20:28:34 logging in to vault with approle auth: success!
-2022/01/11 20:28:34 auth token: successfully renewed
-2022/01/11 20:29:58 auth token: successfully renewed
-2022/01/11 20:31:23 auth token: successfully renewed
+2022/01/11 20:28:34 auth token: successfully renewed; remaining duration: 120s
+2022/01/11 20:29:58 auth token: successfully renewed; remaining duration: 120s
+2022/01/11 20:31:23 auth token: successfully renewed; remaining duration: 120s
 ```
 
 Examine the logs for database credentials renew / reconnect cycle:

--- a/vault_renewal.go
+++ b/vault_renewal.go
@@ -133,8 +133,8 @@ func (v *Vault) renewLeases(ctx context.Context, authToken, databaseCredentialsL
 
 		// RenewCh is a channel that receives a message when a successful
 		// renewal takes place and includes metadata about the renewal.
-		case <-authTokenWatcher.RenewCh():
-			log.Printf("auth token: successfully renewed")
+		case info := <-authTokenWatcher.RenewCh():
+			log.Printf("auth token: successfully renewed; remaining duration: %ds", info.Secret.Auth.LeaseDuration)
 
 		case info := <-databaseCredentialsWatcher.RenewCh():
 			log.Printf("database credentials: successfully renewed; remaining lease duration: %ds", info.Secret.LeaseDuration)


### PR DESCRIPTION
# Description

A simple change to display the remaining auth token duration in the log

## Type of change

- [x] New feature (non-breaking change that adds a new functionality)

# How Has This Been Tested?

Ran locally & observed the output. I updated the `README.md` accordingly.
